### PR TITLE
Initialize carrier filter tap

### DIFF
--- a/src/Vocode_O_Matic.hpp
+++ b/src/Vocode_O_Matic.hpp
@@ -349,6 +349,7 @@ struct Vocode_O_Matic : Module {
     for (int i = 0; i < NR_OF_BANDS; i++) {
      for (int j = 0; j < 3; j++) {
           ym[i][j] = 0.0;
+          yc[i][j] = 0.0;
       }
       ym_env[i][0] = 0.0; // Envelope of modulator.
       ym_env[i][1] = 0.0;


### PR DESCRIPTION
It looks like your issue is that you did not initialize the carrier filter tap array. Sometimes the plugin started with an array with garbage values that caused them to propagate to the outputs, and as this is an iterative feedback process, the garbage just stayed in the loops.